### PR TITLE
♻️ replace ts-luxon with luxon

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "@angular/platform-server": "^17.0.0",
     "@angular/router": "^17.0.0",
     "@angular/ssr": "^17.0.0",
+    "luxon": "^3.4.4",
     "rxjs": "^7.4.0",
-    "ts-luxon": "^4.3.2",
     "tslib": "^2.5.2",
     "zone.js": "~0.14.0"
   },
@@ -66,6 +66,7 @@
     "@fontsource/material-icons": "^5.0.7",
     "@fontsource/roboto": "^5.0.8",
     "@types/jest": "^29.5.10",
+    "@types/luxon": "^3.3.6",
     "@types/node": "^18.0.0",
     "@types/prismjs": "^1.26.0",
     "@typescript-eslint/eslint-plugin": "^6.11.0",

--- a/projects/demo/src/app/components/demo/demo.component.ts
+++ b/projects/demo/src/app/components/demo/demo.component.ts
@@ -17,7 +17,7 @@ import {
 } from '@alexfriesen/ngx-mat-timepicker';
 
 import { CodeViewerComponent } from '../code-viewer/code-viewer.component';
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 interface NgxMatTimepickerTheme {
   description: string;

--- a/projects/ngx-mat-timepicker/ng-package.json
+++ b/projects/ngx-mat-timepicker/ng-package.json
@@ -5,6 +5,6 @@
     "entryFile": "src/public-api.ts"
   },
   "allowedNonPeerDependencies": [
-    "ts-luxon"
+    "luxon"
   ]
 }

--- a/projects/ngx-mat-timepicker/package.json
+++ b/projects/ngx-mat-timepicker/package.json
@@ -20,7 +20,7 @@
     "Time picker"
   ],
   "dependencies": {
-    "ts-luxon": "^4.3.2",
+    "luxon": "^3.4.4",
     "tslib": "^2.5.2"
   },
   "peerDependencies": {

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-12-hours-face/ngx-mat-timepicker-12-hours-face.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-12-hours-face/ngx-mat-timepicker-12-hours-face.component.spec.ts
@@ -5,7 +5,7 @@ import {NgxMatTimepicker12HoursFaceComponent} from "./ngx-mat-timepicker-12-hour
 import {NgxMatTimepickerPeriods} from "../../models/ngx-mat-timepicker-periods.enum";
 import {NgxMatTimepickerUtils} from "../../utils/ngx-mat-timepicker.utils";
 //
-import {DateTime} from "ts-luxon";
+import {DateTime} from 'luxon';
 
 describe("NgxMatTimepicker12HoursFaceComponent", () => {
     let fixture: ComponentFixture<NgxMatTimepicker12HoursFaceComponent>;

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-24-hours-face/ngx-mat-timepicker-24-hours-face.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-24-hours-face/ngx-mat-timepicker-24-hours-face.component.spec.ts
@@ -4,7 +4,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { NgxMatTimepicker24HoursFaceComponent } from './ngx-mat-timepicker-24-hours-face.component';
 import { NgxMatTimepickerUtils } from '../../utils/ngx-mat-timepicker.utils';
 
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 describe('NgxMatTimepicker24HoursFaceComponent', () => {
   let fixture: ComponentFixture<NgxMatTimepicker24HoursFaceComponent>;

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
@@ -7,7 +7,7 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 import { NgxMatTimepickerModule } from '../../ngx-mat-timepicker.module';
 import { NgxMatTimepickerUnits } from '../../models/ngx-mat-timepicker-units.enum';

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
@@ -9,10 +9,11 @@ import {
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { DateTime } from 'luxon';
 
-import { NgxMatTimepickerModule } from '../../ngx-mat-timepicker.module';
 import { NgxMatTimepickerUnits } from '../../models/ngx-mat-timepicker-units.enum';
 import { NgxMatTimepickerParserPipe } from '../../pipes/ngx-mat-timepicker-parser.pipe';
 import { NgxMatTimepickerTimeFormatterPipe } from '../../pipes/ngx-mat-timepicker-time-formatter.pipe';
+import { NGX_MAT_TIMEPICKER_LOCALE } from '../../tokens/ngx-mat-timepicker-time-locale.token';
+import { NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM } from '../../tokens/ngx-mat-timepicker-time-numberingsystem.token';
 import { NgxMatTimepickerControlComponent } from './ngx-mat-timepicker-control.component';
 
 describe('NgxMatTimepickerControlComponent', () => {
@@ -21,11 +22,10 @@ describe('NgxMatTimepickerControlComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        NgxMatTimepickerModule.setLocale('ar-AE'),
-      ],
+      imports: [NoopAnimationsModule],
       providers: [
+        { provide: NGX_MAT_TIMEPICKER_LOCALE, useValue: 'ar-AE' },
+        { provide: NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM, useValue: 'arab' },
         NgxMatTimepickerParserPipe,
         NgxMatTimepickerTimeFormatterPipe,
       ],
@@ -318,8 +318,7 @@ describe('NgxMatTimepickerControlComponent', () => {
   });
 
   describe('onModelChange', () => {
-    // arabic is broken in ts-luxon
-    it.skip('should parse value and set it to time property', () => {
+    it('should parse value and set it to time property', () => {
       const unparsedTime = DateTime.fromObject(
         { minute: 10 },
         { numberingSystem: 'arab' },

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.spec.ts
@@ -6,15 +6,15 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-//
+import { DateTime } from 'luxon';
+
 import { NgxMatTimepickerDialControlComponent } from './ngx-mat-timepicker-dial-control.component';
 import { NgxMatTimepickerUnits } from '../../models/ngx-mat-timepicker-units.enum';
 import { NgxMatTimepickerTimeLocalizerPipe } from '../../pipes/ngx-mat-timepicker-time-localizer.pipe';
 import { NgxMatTimepickerParserPipe } from '../../pipes/ngx-mat-timepicker-parser.pipe';
 import { NGX_MAT_TIMEPICKER_LOCALE } from '../../tokens/ngx-mat-timepicker-time-locale.token';
+import { NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM } from '../../tokens/ngx-mat-timepicker-time-numberingsystem.token';
 import { NgxMatTimepickerUtils } from '../../utils/ngx-mat-timepicker.utils';
-//
-import { DateTime } from 'luxon';
 
 describe('NgxMatTimepickerDialControlComponent', () => {
   let fixture: ComponentFixture<NgxMatTimepickerDialControlComponent>;
@@ -30,6 +30,7 @@ describe('NgxMatTimepickerDialControlComponent', () => {
       providers: [
         NgxMatTimepickerParserPipe,
         { provide: NGX_MAT_TIMEPICKER_LOCALE, useValue: 'ar-AE' },
+        { provide: NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM, useValue: 'arab' },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).createComponent(NgxMatTimepickerDialControlComponent);
@@ -186,8 +187,7 @@ describe('NgxMatTimepickerDialControlComponent', () => {
   });
 
   describe('onModelChange', () => {
-    // arabic is broken in ts-luxon
-    it.skip('should parse value and set it to time property', () => {
+    it('should parse value and set it to time property', () => {
       const unparsedTime = DateTime.fromObject(
         { minute: 10 },
         { numberingSystem: 'arab' },

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.spec.ts
@@ -14,7 +14,7 @@ import { NgxMatTimepickerParserPipe } from '../../pipes/ngx-mat-timepicker-parse
 import { NGX_MAT_TIMEPICKER_LOCALE } from '../../tokens/ngx-mat-timepicker-time-locale.token';
 import { NgxMatTimepickerUtils } from '../../utils/ngx-mat-timepicker.utils';
 //
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 describe('NgxMatTimepickerDialControlComponent', () => {
   let fixture: ComponentFixture<NgxMatTimepickerDialControlComponent>;

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial/ngx-mat-timepicker-dial.component.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial/ngx-mat-timepicker-dial.component.ts
@@ -20,7 +20,7 @@ import { NgxMatTimepickerUtils } from '../../utils/ngx-mat-timepicker.utils';
 import { NgxMatTimepickerPeriodComponent } from '../ngx-mat-timepicker-period/ngx-mat-timepicker-period.component';
 import { NgxMatTimepickerDialControlComponent } from '../ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component';
 //
-import { DateTime, Info } from 'ts-luxon';
+import { DateTime, Info } from 'luxon';
 
 @Component({
   selector: 'ngx-mat-timepicker-dial',

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.spec.ts
@@ -16,7 +16,7 @@ import { NGX_MAT_TIMEPICKER_LOCALE } from '../../tokens/ngx-mat-timepicker-time-
 import { NgxMatTimepickerAdapter } from '../../services/ngx-mat-timepicker-adapter';
 import { NgxMatTimepickerUtils } from '../../utils/ngx-mat-timepicker.utils';
 
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 describe('NgxMatTimepickerFieldComponent', () => {
   let component: NgxMatTimepickerFieldComponent;

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.ts
@@ -38,7 +38,7 @@ import { NgxMatTimepickerToggleIconDirective } from '../../directives/ngx-mat-ti
 import { NgxMatTimepickerToggleComponent } from '../ngx-mat-timepicker-toggle/ngx-mat-timepicker-toggle.component';
 import { NgxMatTimepickerControlComponent } from '../ngx-mat-timepicker-control/ngx-mat-timepicker-control.component';
 
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 @Component({
   selector: 'ngx-mat-timepicker-field',
@@ -338,7 +338,7 @@ export class NgxMatTimepickerFieldComponent
       time,
       this.min as DateTime,
       this.max as DateTime,
-      'minutes',
+      'minute',
       null,
       this.format,
     );

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-hours-face/ngx-mat-timepicker-hours-face.directive.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-hours-face/ngx-mat-timepicker-hours-face.directive.ts
@@ -5,7 +5,7 @@ import {NgxMatTimepickerClockFace} from "../../models/ngx-mat-timepicker-clock-f
 import {NgxMatTimepickerFormatType} from "../../models/ngx-mat-timepicker-format.type";
 import {NgxMatTimepickerUtils} from "../../utils/ngx-mat-timepicker.utils";
 //
-import {DateTime} from "ts-luxon";
+import {DateTime} from 'luxon';
 
 @Directive({
     // eslint-disable-next-line @angular-eslint/directive-selector

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-minutes-face/ngx-mat-timepicker-minutes-face.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-minutes-face/ngx-mat-timepicker-minutes-face.component.spec.ts
@@ -5,7 +5,7 @@ import { NgxMatTimepickerMinutesFaceComponent } from './ngx-mat-timepicker-minut
 import { NgxMatTimepickerUtils } from '../../utils/ngx-mat-timepicker.utils';
 import { NgxMatTimepickerPeriods } from '../../models/ngx-mat-timepicker-periods.enum';
 
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 describe('NgxMatTimepickerMinutesFaceComponent', () => {
   let fixture: ComponentFixture<NgxMatTimepickerMinutesFaceComponent>;

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-minutes-face/ngx-mat-timepicker-minutes-face.component.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-minutes-face/ngx-mat-timepicker-minutes-face.component.ts
@@ -8,7 +8,7 @@ import {NgxMatTimepickerPeriods} from "../../models/ngx-mat-timepicker-periods.e
 import {NgxMatTimepickerUtils} from "../../utils/ngx-mat-timepicker.utils";
 import { NgxMatTimepickerFaceComponent } from "../ngx-mat-timepicker-face/ngx-mat-timepicker-face.component";
 //
-import {DateTime} from "ts-luxon";
+import {DateTime} from 'luxon';
 
 @Component({
     selector: "ngx-mat-timepicker-minutes-face",

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-period/ngx-mat-timepicker-period.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-period/ngx-mat-timepicker-period.component.spec.ts
@@ -7,7 +7,7 @@ import { NgxMatTimepickerUnits } from '../../models/ngx-mat-timepicker-units.enu
 import { NgxMatTimepickerPeriods } from '../../models/ngx-mat-timepicker-periods.enum';
 import { NgxMatTimepickerUtils } from '../../utils/ngx-mat-timepicker.utils';
 //
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 describe('NgxMatTimepickerPeriodComponent', () => {
   let fixture: ComponentFixture<NgxMatTimepickerPeriodComponent>;

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-period/ngx-mat-timepicker-period.component.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-period/ngx-mat-timepicker-period.component.ts
@@ -20,7 +20,7 @@ import { NgxMatTimepickerUnits } from '../../models/ngx-mat-timepicker-units.enu
 import { NgxMatTimepickerClockFace } from '../../models/ngx-mat-timepicker-clock-face.interface';
 import { NgxMatTimepickerUtils } from '../../utils/ngx-mat-timepicker.utils';
 //
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 @Component({
   selector: 'ngx-mat-timepicker-period',

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker/ngx-mat-timepicker.component.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker/ngx-mat-timepicker.component.ts
@@ -26,7 +26,7 @@ import { NgxMatTimepickerRef } from '../../models/ngx-mat-timepicker-ref.interfa
 import { NgxMatTimepickerDialogComponent } from '../ngx-mat-timepicker-dialog/ngx-mat-timepicker-dialog.component';
 import { NGX_MAT_TIMEPICKER_CONFIG } from '../../tokens/ngx-mat-timepicker-config.token';
 //
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 import { BehaviorSubject } from 'rxjs';
 import { NgxMatTimepickerStandaloneComponent } from '../ngx-mat-timepicker-standalone/ngx-mat-timepicker-standalone.component';
 

--- a/projects/ngx-mat-timepicker/src/lib/directives/ngx-mat-timepicker.directive.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/directives/ngx-mat-timepicker.directive.spec.ts
@@ -6,7 +6,7 @@ import { NgxMatTimepickerModule } from '../ngx-mat-timepicker.module';
 import { NgxMatTimepickerDirective } from './ngx-mat-timepicker.directive';
 import { NgxMatTimepickerComponent } from '../components/ngx-mat-timepicker/ngx-mat-timepicker.component';
 
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 @Component({
   template: `

--- a/projects/ngx-mat-timepicker/src/lib/directives/ngx-mat-timepicker.directive.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/directives/ngx-mat-timepicker.directive.spec.ts
@@ -132,7 +132,7 @@ describe('NgxMatTimepickerDirective', () => {
 
   it('should call console.warn if time is not between min and max(inclusively) value', () => {
     directive.timepicker = timepickerComponent;
-    const spy = jest.spyOn(console, 'warn');
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => null);
 
     directive.min = '11:00 am';
     directive.value = '10:00 am';

--- a/projects/ngx-mat-timepicker/src/lib/directives/ngx-mat-timepicker.directive.ts
+++ b/projects/ngx-mat-timepicker/src/lib/directives/ngx-mat-timepicker.directive.ts
@@ -20,7 +20,7 @@ import { NgxMatTimepickerAdapter } from '../services/ngx-mat-timepicker-adapter'
 import { NgxMatTimepickerLocaleService } from '../services/ngx-mat-timepicker-locale.service';
 //
 import { Subject, takeUntil } from 'rxjs';
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 @Directive({
   // eslint-disable-next-line @angular-eslint/directive-selector
@@ -133,7 +133,7 @@ export class NgxMatTimepickerDirective
       time,
       this._min as DateTime,
       this._max as DateTime,
-      'minutes',
+      'minute',
       this._timepicker.minutesGap,
       this._format,
     );

--- a/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-config.interface.ts
+++ b/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-config.interface.ts
@@ -4,7 +4,7 @@ import { ThemePalette } from '@angular/material/core';
 import { NgxMatTimepickerFormatType } from './ngx-mat-timepicker-format.type';
 import { NgxMatTimepickerRef } from './ngx-mat-timepicker-ref.interface';
 //
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 export interface NgxMatTimepickerConfig {
   appendToInput: boolean;

--- a/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-config.interface.ts
+++ b/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-config.interface.ts
@@ -1,10 +1,9 @@
 import { TemplateRef } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
-//
+import type { DateTime } from 'luxon';
+
 import { NgxMatTimepickerFormatType } from './ngx-mat-timepicker-format.type';
 import { NgxMatTimepickerRef } from './ngx-mat-timepicker-ref.interface';
-//
-import { DateTime } from 'luxon';
 
 export interface NgxMatTimepickerConfig {
   appendToInput: boolean;

--- a/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-disabled-config.interface.ts
+++ b/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-disabled-config.interface.ts
@@ -1,7 +1,7 @@
 import {NgxMatTimepickerFormatType} from "./ngx-mat-timepicker-format.type";
 import { NgxMatTimepickerPeriods } from "./ngx-mat-timepicker-periods.enum";
 //
-import { DateTime } from "ts-luxon";
+import { DateTime } from 'luxon';
 
 export interface NgxMatTimepickerDisabledConfig {
     format: NgxMatTimepickerFormatType;

--- a/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-measures.enum.ts
+++ b/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-measures.enum.ts
@@ -1,4 +1,4 @@
 export enum NgxMatTimepickerMeasure {
-    hour = "hour",
-    minute = "minute"
+  hour = 'hour',
+  minute = 'minute',
 }

--- a/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-options.interface.ts
+++ b/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-options.interface.ts
@@ -1,4 +1,4 @@
-import { LocaleOptions } from "ts-luxon";
+import { LocaleOptions } from 'luxon';
 
 export interface NgxMatTimepickerOptions extends LocaleOptions {
     format?: number;

--- a/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-units.enum.ts
+++ b/projects/ngx-mat-timepicker/src/lib/models/ngx-mat-timepicker-units.enum.ts
@@ -1,4 +1,4 @@
 export enum NgxMatTimepickerUnits {
-    HOUR,
-    MINUTE
+  HOUR,
+  MINUTE,
 }

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.spec.ts
@@ -1,13 +1,30 @@
-import { NgxMatTimepickerParserPipe } from './ngx-mat-timepicker-parser.pipe';
-import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
-import { NgxMatTimepickerLocaleService } from '../services/ngx-mat-timepicker-locale.service';
+import { TestBed } from '@angular/core/testing';
 import { DateTime } from 'luxon';
 
+import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
+import { NGX_MAT_TIMEPICKER_LOCALE } from '../tokens/ngx-mat-timepicker-time-locale.token';
+import { NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM } from '../tokens/ngx-mat-timepicker-time-numberingsystem.token';
+import { NgxMatTimepickerParserPipe } from './ngx-mat-timepicker-parser.pipe';
+
 describe('NgxMatTimepickerParserPipe', () => {
-  const locale = 'ar-AE';
-  const pipe = new NgxMatTimepickerParserPipe(
-    new NgxMatTimepickerLocaleService(locale),
-  );
+  let pipe: NgxMatTimepickerParserPipe;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        NgxMatTimepickerParserPipe,
+        {
+          provide: NGX_MAT_TIMEPICKER_LOCALE,
+          useValue: 'ar-AE',
+        },
+        {
+          provide: NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM,
+          useValue: 'arab',
+        },
+      ],
+    });
+    pipe = TestBed.inject(NgxMatTimepickerParserPipe);
+  });
 
   it('should create an instance', () => {
     expect(pipe).toBeTruthy();
@@ -23,47 +40,44 @@ describe('NgxMatTimepickerParserPipe', () => {
     expect(pipe.transform('', NgxMatTimepickerUnits.HOUR)).toBe(expected);
   });
 
-  // arabic is broken in ts-luxon
-  it.skip('should return unparsed time if number provided', () => {
+  it('should return unparsed time if number provided', () => {
     const time = 5;
 
     expect(pipe.transform(time)).toBe(`${time}`);
   });
 
-  // arabic is broken in ts-luxon
-  it.skip('should parse arabian hour to latin', () => {
+  it('should parse arabian hour to latin', () => {
     const unparsedHours = Array(24)
       .fill(0)
       .map((v, i) => v + i);
 
-    unparsedHours.forEach((hour) => {
+    for (const hour of unparsedHours) {
       const unparsedHour = DateTime.fromObject(
         { hour },
         { numberingSystem: 'arab' },
-      ).toFormat('H');
+      ).toFormat('HH');
 
       expect(pipe.transform(unparsedHour, NgxMatTimepickerUnits.HOUR)).toBe(
-        hour,
+        `${hour}`,
       );
-    });
+    }
   });
 
-  // arabic is broken in ts-luxon
-  it.skip('should parse arabian minute to latin', () => {
+  it('should parse arabian minute to latin', () => {
     const unparsedMinutes = Array(59)
       .fill(0)
       .map((v, i) => v + i);
 
-    unparsedMinutes.forEach((minute) => {
+    for (const minute of unparsedMinutes) {
       const unparsedMinute = DateTime.fromObject(
         { minute },
         { numberingSystem: 'arab' },
-      ).toFormat('m');
+      ).toFormat('mm');
 
       expect(pipe.transform(unparsedMinute, NgxMatTimepickerUnits.MINUTE)).toBe(
-        minute,
+        `${minute}`,
       );
-    });
+    }
   });
 
   it('should throw an error when cannot parse provided time', () => {

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.spec.ts
@@ -1,7 +1,7 @@
 import { NgxMatTimepickerParserPipe } from './ngx-mat-timepicker-parser.pipe';
 import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
 import { NgxMatTimepickerLocaleService } from '../services/ngx-mat-timepicker-locale.service';
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 describe('NgxMatTimepickerParserPipe', () => {
   const locale = 'ar-AE';

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.ts
@@ -1,51 +1,64 @@
-import {Injectable, Pipe, PipeTransform} from "@angular/core";
-//
-import {NgxMatTimepickerUnits} from "../models/ngx-mat-timepicker-units.enum";
-import {NgxMatTimepickerMeasure} from "../models/ngx-mat-timepicker-measures.enum";
-import {NgxMatTimepickerLocaleService} from "../services/ngx-mat-timepicker-locale.service";
-//
-import {DateTime, NumberingSystem} from 'luxon';
+import { Injectable, Pipe, PipeTransform, inject } from '@angular/core';
+
+import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
+import { NgxMatTimepickerMeasure } from '../models/ngx-mat-timepicker-measures.enum';
+import { NgxMatTimepickerLocaleService } from '../services/ngx-mat-timepicker-locale.service';
+
+import { DateTime } from 'luxon';
 
 @Pipe({
-    name: "ngxMatTimepickerParser",
-    standalone: true
+  name: 'ngxMatTimepickerParser',
+  standalone: true,
 })
 @Injectable()
 export class NgxMatTimepickerParserPipe implements PipeTransform {
+  private readonly _timepickerLocaleSrv = inject(NgxMatTimepickerLocaleService);
 
-    private get _locale(): string {
-        return this._timepickerLocaleSrv.locale;
+  private get _locale(): string {
+    return this._timepickerLocaleSrv.locale;
+  }
+
+  private get _numberingSystem(): string {
+    return this._timepickerLocaleSrv.numberingSystem;
+  }
+
+  transform(
+    time: string | number,
+    timeUnit = NgxMatTimepickerUnits.HOUR,
+  ): string {
+    if (time == null || time === '') {
+      return '';
     }
 
-    private readonly _numberingSystem: NumberingSystem;
-
-    constructor(private _timepickerLocaleSrv: NgxMatTimepickerLocaleService) {
-        this._numberingSystem = DateTime.local().setLocale(this._locale).resolvedLocaleOptions().numberingSystem as NumberingSystem;
+    if (!isNaN(+time)) {
+      return `${time}`;
     }
 
-    transform(time: string | number, timeUnit = NgxMatTimepickerUnits.HOUR): string {
-        if (time == null || time === "") {
-            return "";
-        }
-
-        if (!isNaN(+time)) {
-            return `${time}`;
-        }
-
-        if (timeUnit === NgxMatTimepickerUnits.MINUTE) {
-            return this._parseTime(time, "mm", NgxMatTimepickerMeasure.minute).toString();
-        }
-
-        return this._parseTime(time, "HH", NgxMatTimepickerMeasure.hour).toString();
+    if (timeUnit === NgxMatTimepickerUnits.MINUTE) {
+      return this._parseTime(
+        time,
+        'mm',
+        NgxMatTimepickerMeasure.minute,
+      ).toString();
     }
 
-    private _parseTime(time: string | number, format: string, timeMeasure: NgxMatTimepickerMeasure): number {
-        const parsedTime = DateTime.fromFormat(String(time), format, {numberingSystem: this._numberingSystem})[timeMeasure];
-        if (!isNaN(parsedTime)) {
-            return parsedTime;
-        }
+    return this._parseTime(time, 'HH', NgxMatTimepickerMeasure.hour).toString();
+  }
 
-        throw new Error(`Cannot parse time - ${time}`);
+  private _parseTime(
+    time: string | number,
+    format: string,
+    timeMeasure: NgxMatTimepickerMeasure,
+  ): number {
+    const parsedTime = DateTime.fromFormat(String(time), format, {
+      locale: this._locale,
+      numberingSystem: this._numberingSystem,
+    })[timeMeasure];
+
+    if (!isNaN(parsedTime)) {
+      return parsedTime;
     }
 
+    throw new Error(`Cannot parse time - ${time}`);
+  }
 }

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.ts
@@ -4,7 +4,7 @@ import {NgxMatTimepickerUnits} from "../models/ngx-mat-timepicker-units.enum";
 import {NgxMatTimepickerMeasure} from "../models/ngx-mat-timepicker-measures.enum";
 import {NgxMatTimepickerLocaleService} from "../services/ngx-mat-timepicker-locale.service";
 //
-import {DateTime, NumberingSystem} from "ts-luxon";
+import {DateTime, NumberingSystem} from 'luxon';
 
 @Pipe({
     name: "ngxMatTimepickerParser",

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-formatter.pipe.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-formatter.pipe.ts
@@ -1,8 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
-//
-import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
-//
 import { DateTime } from 'luxon';
+
+import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
 
 @Pipe({
   name: 'timeFormatter',

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-formatter.pipe.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-formatter.pipe.ts
@@ -2,7 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 //
 import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
 //
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 @Pipe({
   name: 'timeFormatter',

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-localizer.pipe.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-localizer.pipe.spec.ts
@@ -1,7 +1,7 @@
 import { NgxMatTimepickerTimeLocalizerPipe } from './ngx-mat-timepicker-time-localizer.pipe';
 import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
 import { NgxMatTimepickerLocaleService } from '../services/ngx-mat-timepicker-locale.service';
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 describe('NgxMatTimepickerTimeLocalizerPipe', () => {
   const defaultLocale = 'en-US';

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-localizer.pipe.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-localizer.pipe.spec.ts
@@ -1,13 +1,27 @@
-import { NgxMatTimepickerTimeLocalizerPipe } from './ngx-mat-timepicker-time-localizer.pipe';
-import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
-import { NgxMatTimepickerLocaleService } from '../services/ngx-mat-timepicker-locale.service';
+import { TestBed } from '@angular/core/testing';
 import { DateTime } from 'luxon';
+
+import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
+import { NGX_MAT_TIMEPICKER_LOCALE } from '../tokens/ngx-mat-timepicker-time-locale.token';
+import { NgxMatTimepickerTimeLocalizerPipe } from './ngx-mat-timepicker-time-localizer.pipe';
 
 describe('NgxMatTimepickerTimeLocalizerPipe', () => {
   const defaultLocale = 'en-US';
-  const pipe = new NgxMatTimepickerTimeLocalizerPipe(
-    new NgxMatTimepickerLocaleService(defaultLocale),
-  );
+  let pipe: NgxMatTimepickerTimeLocalizerPipe;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        NgxMatTimepickerTimeLocalizerPipe,
+        {
+          provide: NGX_MAT_TIMEPICKER_LOCALE,
+          useValue: defaultLocale,
+        },
+      ],
+    });
+
+    pipe = TestBed.inject(NgxMatTimepickerTimeLocalizerPipe);
+  });
 
   it('should create an instance', () => {
     expect(pipe).toBeTruthy();

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-localizer.pipe.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-localizer.pipe.ts
@@ -1,48 +1,63 @@
-import {Pipe, PipeTransform} from "@angular/core";
-//
-import {NgxMatTimepickerLocaleService} from "../services/ngx-mat-timepicker-locale.service";
-import {NgxMatTimepickerUnits} from "../models/ngx-mat-timepicker-units.enum";
-import {NgxMatTimepickerMeasure} from "../models/ngx-mat-timepicker-measures.enum";
-//
-import {DateTime} from 'luxon';
+import { Pipe, PipeTransform, inject } from '@angular/core';
+import { DateTime } from 'luxon';
+
+import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
+import { NgxMatTimepickerMeasure } from '../models/ngx-mat-timepicker-measures.enum';
+import { NgxMatTimepickerLocaleService } from '../services/ngx-mat-timepicker-locale.service';
 
 @Pipe({
-    name: "timeLocalizer",
-    standalone: true
+  name: 'timeLocalizer',
+  standalone: true,
 })
 export class NgxMatTimepickerTimeLocalizerPipe implements PipeTransform {
+  private readonly _timepickerLocaleSrv = inject(NgxMatTimepickerLocaleService);
 
-    private get _locale(): string {
-        return this._timepickerLocaleSrv.locale;
+  private get _locale(): string {
+    return this._timepickerLocaleSrv.locale;
+  }
+
+  private get _numberingSystem() {
+    return this._timepickerLocaleSrv.numberingSystem;
+  }
+
+  transform(
+    time: number | string,
+    timeUnit: NgxMatTimepickerUnits,
+    isKeyboardEnabled = false,
+  ): string {
+    if (time == null || time === '') {
+      return '';
     }
 
-    constructor(private _timepickerLocaleSrv: NgxMatTimepickerLocaleService) {
+    switch (timeUnit) {
+      case NgxMatTimepickerUnits.HOUR: {
+        const format = time === 0 || isKeyboardEnabled ? 'HH' : 'H';
+
+        return this._formatTime(NgxMatTimepickerMeasure.hour, time, format);
+      }
+      case NgxMatTimepickerUnits.MINUTE:
+        return this._formatTime(NgxMatTimepickerMeasure.minute, time, 'mm');
+      default:
+        throw new Error(`There is no Time Unit with type ${timeUnit}`);
     }
+  }
 
-    transform(time: number | string, timeUnit: NgxMatTimepickerUnits, isKeyboardEnabled = false): string {
-        if (time == null || time === "") {
-            return "";
-        }
-
-        switch (timeUnit) {
-            case NgxMatTimepickerUnits.HOUR: {
-                const format = (time === 0 || isKeyboardEnabled) ? "HH" : "H";
-
-                return this._formatTime(NgxMatTimepickerMeasure.hour, time, format);
-            }
-            case NgxMatTimepickerUnits.MINUTE:
-                return this._formatTime(NgxMatTimepickerMeasure.minute, time, "mm");
-            default:
-                throw new Error(`There is no Time Unit with type ${timeUnit}`);
-        }
+  private _formatTime(
+    timeMeasure: NgxMatTimepickerMeasure,
+    time: string | number,
+    format: string,
+  ): string {
+    try {
+      return DateTime.fromObject({ [timeMeasure]: +time })
+        .reconfigure({
+          locale: this._locale,
+          numberingSystem: this._numberingSystem,
+        })
+        .toFormat(format);
+    } catch {
+      throw new Error(
+        `Cannot format provided time - ${time} to locale - ${this._locale}`,
+      );
     }
-
-    private _formatTime(timeMeasure: NgxMatTimepickerMeasure, time: string | number, format: string): string {
-        try {
-            return DateTime.fromObject({[timeMeasure]: +time}).setLocale(this._locale).toFormat(format);
-        }
-        catch {
-            throw new Error(`Cannot format provided time - ${time} to locale - ${this._locale}`);
-        }
-    }
+  }
 }

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-localizer.pipe.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-localizer.pipe.ts
@@ -4,7 +4,7 @@ import {NgxMatTimepickerLocaleService} from "../services/ngx-mat-timepicker-loca
 import {NgxMatTimepickerUnits} from "../models/ngx-mat-timepicker-units.enum";
 import {NgxMatTimepickerMeasure} from "../models/ngx-mat-timepicker-measures.enum";
 //
-import {DateTime} from "ts-luxon";
+import {DateTime} from 'luxon';
 
 @Pipe({
     name: "timeLocalizer",

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.spec.ts
@@ -1,0 +1,154 @@
+import { DateTime } from 'luxon';
+
+import { NgxMatTimepickerAdapter } from './ngx-mat-timepicker-adapter';
+import { NgxMatTimepickerPeriods } from '../models/ngx-mat-timepicker-periods.enum';
+
+describe('NgxMatTimepickerAdapter', () => {
+  describe('formatHour', () => {
+    it('should format hour according to time format (12 or 24)', () => {
+      expect(
+        NgxMatTimepickerAdapter.formatHour(1, 12, NgxMatTimepickerPeriods.AM),
+      ).toBe(1);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(1, 12, NgxMatTimepickerPeriods.PM),
+      ).toBe(13);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(12, 12, NgxMatTimepickerPeriods.AM),
+      ).toBe(0);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(12, 12, NgxMatTimepickerPeriods.PM),
+      ).toBe(12);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(12, 24, NgxMatTimepickerPeriods.AM),
+      ).toBe(12);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(12, 24, NgxMatTimepickerPeriods.PM),
+      ).toBe(12);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(13, 12, NgxMatTimepickerPeriods.AM),
+      ).toBe(0);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(13, 12, NgxMatTimepickerPeriods.PM),
+      ).toBe(12);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(23, 12, NgxMatTimepickerPeriods.AM),
+      ).toBe(0);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(23, 12, NgxMatTimepickerPeriods.PM),
+      ).toBe(12);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(24, 12, NgxMatTimepickerPeriods.AM),
+      ).toBe(0);
+      expect(
+        NgxMatTimepickerAdapter.formatHour(24, 12, NgxMatTimepickerPeriods.PM),
+      ).toBe(12);
+    });
+  });
+
+  describe('formatTime', () => {
+    it('should format time', () => {
+      expect(NgxMatTimepickerAdapter.formatTime('11:00', { format: 12 })).toBe(
+        '11:00 AM',
+      );
+      expect(NgxMatTimepickerAdapter.formatTime('11:00', { format: 24 })).toBe(
+        '11:00',
+      );
+    });
+  });
+
+  describe('fromDateTimeToString', () => {
+    it('should format time', () => {
+      const time = DateTime.fromObject({ hour: 11, minute: 0 });
+      expect(NgxMatTimepickerAdapter.fromDateTimeToString(time, 12)).toBe(
+        '11:00 AM',
+      );
+      expect(NgxMatTimepickerAdapter.fromDateTimeToString(time, 24)).toBe(
+        '11:00',
+      );
+    });
+  });
+
+  describe('isBetween', () => {
+    it('should check if time is between', () => {
+      const time = DateTime.fromObject({ hour: 11, minute: 0 });
+      const start = DateTime.fromObject({ hour: 10, minute: 0 });
+      const end = DateTime.fromObject({ hour: 12, minute: 0 });
+      expect(NgxMatTimepickerAdapter.isBetween(time, start, end)).toBe(true);
+    });
+  });
+
+  describe('isSameOrAfter', () => {
+    it('should check if time is same or after', () => {
+      const time = DateTime.fromObject({ hour: 11, minute: 0 });
+      const start = DateTime.fromObject({ hour: 10, minute: 0 });
+      expect(NgxMatTimepickerAdapter.isSameOrAfter(time, start)).toBe(true);
+    });
+  });
+
+  describe('isSameOrBefore', () => {
+    it('should check if time is same or before', () => {
+      const time = DateTime.fromObject({ hour: 11, minute: 0 });
+      const end = DateTime.fromObject({ hour: 12, minute: 0 });
+      expect(NgxMatTimepickerAdapter.isSameOrBefore(time, end)).toBe(true);
+    });
+  });
+
+  describe('isTimeAvailable', () => {
+    it('should check if time is available', () => {
+      const start = DateTime.fromObject({ hour: 10, minute: 0 });
+      const end = DateTime.fromObject({ hour: 12, minute: 0 });
+      expect(NgxMatTimepickerAdapter.isTimeAvailable('11:00', start, end)).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('isTwentyFour', () => {
+    it('should check if format is 24', () => {
+      expect(NgxMatTimepickerAdapter.isTwentyFour(12)).toBe(false);
+      expect(NgxMatTimepickerAdapter.isTwentyFour(24)).toBe(true);
+    });
+  });
+
+  describe('parseTime', () => {
+    it('should parse time', () => {
+      const time = DateTime.fromObject(
+        { hour: 11, minute: 0 },
+        { locale: 'en-US', numberingSystem: 'latn' },
+      );
+      expect(
+        NgxMatTimepickerAdapter.parseTime('11:00', {
+          locale: 'en-US',
+          numberingSystem: 'latn',
+        }),
+      ).toEqual(time);
+    });
+  });
+
+  describe('toLocaleTimeString', () => {
+    it('should convert provided time (en-US) to provided locale (ar-AE) in 12-hours format', () => {
+      const expected = '١١:١١ ص';
+      const actual = '11:11 am';
+
+      expect(
+        NgxMatTimepickerAdapter.toLocaleTimeString(actual, {
+          locale: 'ar-AE',
+          numberingSystem: 'arab',
+        }),
+      ).toBe(expected);
+    });
+
+    it('should convert provided time (en-US) to provided locale (ar-AE) in 24-hours format', () => {
+      const expected = '٢١:١١';
+      const actual = '21:11';
+
+      expect(
+        NgxMatTimepickerAdapter.toLocaleTimeString(actual, {
+          locale: 'ar-AE',
+          numberingSystem: 'arab',
+          format: 24,
+        }),
+      ).toBe(expected);
+    });
+  });
+});

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
@@ -3,7 +3,11 @@ import { NgxMatTimepickerFormatType } from '../models/ngx-mat-timepicker-format.
 import { NgxMatTimepickerPeriods } from '../models/ngx-mat-timepicker-periods.enum';
 import { NgxMatTimepickerOptions } from '../models/ngx-mat-timepicker-options.interface';
 //
-import { DateTime, DateTimeUnit, LocaleOptions, NumberingSystem } from 'luxon';
+import { DateTime, LocaleOptions, NumberingSystem } from 'luxon';
+import {
+  DateTimeUnitWithDeprecatedTypes,
+  fixDateTimeUnit,
+} from '../utils/datetime-unit-fix.utils';
 
 // @dynamic
 export class NgxMatTimepickerAdapter {
@@ -25,9 +29,9 @@ export class NgxMatTimepickerAdapter {
     const hour =
       period === NgxMatTimepickerPeriods.AM ? currentHour : currentHour + 12;
 
-    if (period === NgxMatTimepickerPeriods.AM && hour === 12) {
+    if (period === NgxMatTimepickerPeriods.AM && hour >= 12) {
       return 0;
-    } else if (period === NgxMatTimepickerPeriods.PM && hour === 24) {
+    } else if (period === NgxMatTimepickerPeriods.PM && hour >= 24) {
       return 12;
     }
 
@@ -83,8 +87,9 @@ export class NgxMatTimepickerAdapter {
     time: DateTime,
     before: DateTime,
     after: DateTime,
-    unit: DateTimeUnit = 'minute',
+    unit: DateTimeUnitWithDeprecatedTypes = 'minute',
   ): boolean {
+    unit = fixDateTimeUnit(unit);
     const innerUnit = unit === 'hour' ? unit : void 0;
 
     return (
@@ -96,8 +101,9 @@ export class NgxMatTimepickerAdapter {
   static isSameOrAfter(
     time: DateTime,
     compareWith: DateTime,
-    unit: DateTimeUnit = 'minute',
+    unit: DateTimeUnitWithDeprecatedTypes = 'minute',
   ): boolean {
+    unit = fixDateTimeUnit(unit);
     if (unit === 'hour') {
       return time.hour >= compareWith.hour;
     }
@@ -110,8 +116,9 @@ export class NgxMatTimepickerAdapter {
   static isSameOrBefore(
     time: DateTime,
     compareWith: DateTime,
-    unit: DateTimeUnit = 'minute',
+    unit: DateTimeUnitWithDeprecatedTypes = 'minute',
   ): boolean {
+    unit = fixDateTimeUnit(unit);
     if (unit === 'hour') {
       return time.hour <= compareWith.hour;
     }
@@ -125,7 +132,7 @@ export class NgxMatTimepickerAdapter {
     time: string,
     min?: DateTime,
     max?: DateTime,
-    granularity?: DateTimeUnit,
+    granularity?: DateTimeUnitWithDeprecatedTypes,
     minutesGap?: number | null,
     format?: number,
   ): boolean {
@@ -141,6 +148,8 @@ export class NgxMatTimepickerAdapter {
         `Your minutes - ${minutes} doesn't match your minutesGap - ${minutesGap}`,
       );
     }
+
+    granularity = fixDateTimeUnit(granularity);
     const isAfter =
       min && !max && this.isSameOrAfter(convertedTime, min, granularity);
     const isBefore =

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
@@ -1,9 +1,10 @@
-import { NgxMatTimepickerFormat } from '../models/ngx-mat-timepicker-format.enum';
-import { NgxMatTimepickerFormatType } from '../models/ngx-mat-timepicker-format.type';
-import { NgxMatTimepickerPeriods } from '../models/ngx-mat-timepicker-periods.enum';
-import { NgxMatTimepickerOptions } from '../models/ngx-mat-timepicker-options.interface';
-//
 import { DateTime, LocaleOptions, NumberingSystem } from 'luxon';
+
+import { NgxMatTimepickerFormat } from '../models/ngx-mat-timepicker-format.enum';
+import { NgxMatTimepickerPeriods } from '../models/ngx-mat-timepicker-periods.enum';
+import { NgxMatTimepickerFormatType } from '../models/ngx-mat-timepicker-format.type';
+import { NgxMatTimepickerOptions } from '../models/ngx-mat-timepicker-options.interface';
+
 import {
   DateTimeUnitWithDeprecatedTypes,
   fixDateTimeUnit,

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
@@ -3,7 +3,7 @@ import { NgxMatTimepickerFormatType } from '../models/ngx-mat-timepicker-format.
 import { NgxMatTimepickerPeriods } from '../models/ngx-mat-timepicker-periods.enum';
 import { NgxMatTimepickerOptions } from '../models/ngx-mat-timepicker-options.interface';
 //
-import { DateTime, LocaleOptions, NumberingSystem } from 'ts-luxon';
+import { DateTime, DateTimeUnit, LocaleOptions, NumberingSystem } from 'luxon';
 
 // @dynamic
 export class NgxMatTimepickerAdapter {
@@ -83,9 +83,9 @@ export class NgxMatTimepickerAdapter {
     time: DateTime,
     before: DateTime,
     after: DateTime,
-    unit: 'hours' | 'minutes' = 'minutes',
+    unit: DateTimeUnit = 'minute',
   ): boolean {
-    const innerUnit = unit === 'hours' ? unit : void 0;
+    const innerUnit = unit === 'hour' ? unit : void 0;
 
     return (
       this.isSameOrBefore(time, after, innerUnit) &&
@@ -96,9 +96,9 @@ export class NgxMatTimepickerAdapter {
   static isSameOrAfter(
     time: DateTime,
     compareWith: DateTime,
-    unit: 'hours' | 'minutes' = 'minutes',
+    unit: DateTimeUnit = 'minute',
   ): boolean {
-    if (unit === 'hours') {
+    if (unit === 'hour') {
       return time.hour >= compareWith.hour;
     }
 
@@ -110,9 +110,9 @@ export class NgxMatTimepickerAdapter {
   static isSameOrBefore(
     time: DateTime,
     compareWith: DateTime,
-    unit: 'hours' | 'minutes' = 'minutes',
+    unit: DateTimeUnit = 'minute',
   ): boolean {
-    if (unit === 'hours') {
+    if (unit === 'hour') {
       return time.hour <= compareWith.hour;
     }
 
@@ -125,7 +125,7 @@ export class NgxMatTimepickerAdapter {
     time: string,
     min?: DateTime,
     max?: DateTime,
-    granularity?: 'hours' | 'minutes',
+    granularity?: DateTimeUnit,
     minutesGap?: number | null,
     format?: number,
   ): boolean {
@@ -195,7 +195,6 @@ export class NgxMatTimepickerAdapter {
       .reconfigure({
         locale,
         numberingSystem: opts.numberingSystem,
-        defaultToEN: opts.defaultToEN,
         outputCalendar: opts.outputCalendar,
       })
       .toLocaleString({
@@ -219,7 +218,6 @@ export class NgxMatTimepickerAdapter {
         locale: opts.locale,
         numberingSystem: opts.numberingSystem,
         outputCalendar: opts.outputCalendar,
-        defaultToEN: opts.defaultToEN,
       })
       .resolvedLocaleOptions();
 

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-locale.service.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-locale.service.ts
@@ -1,24 +1,38 @@
-import {Inject, Injectable} from "@angular/core";
-//
-import {NGX_MAT_TIMEPICKER_LOCALE} from "../tokens/ngx-mat-timepicker-time-locale.token";
+import { Injectable, inject } from '@angular/core';
+import { DateTime, NumberingSystem } from 'luxon';
+
+import { NGX_MAT_TIMEPICKER_LOCALE } from '../tokens/ngx-mat-timepicker-time-locale.token';
+import { NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM } from '../tokens/ngx-mat-timepicker-time-numberingsystem.token';
 
 @Injectable({
-    providedIn: "root"
+  providedIn: 'root',
 })
 export class NgxMatTimepickerLocaleService {
+  get locale(): string {
+    return this._locale;
+  }
 
-    get locale(): string {
-        return this._locale;
-    }
+  get numberingSystem(): string {
+    return this._numberingSystem;
+  }
 
-    protected _initialLocale: string;
-    protected _locale;
+  private _locale = inject(NGX_MAT_TIMEPICKER_LOCALE);
+  private _numberingSystem = inject(NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM);
 
-    constructor(@Inject(NGX_MAT_TIMEPICKER_LOCALE) initialLocale: string) {
-        this._locale = initialLocale;
-    }
+  updateLocale(newValue: string): void {
+    this._locale = newValue;
+  }
 
-    updateLocale(newValue: string): void {
-        this._locale = newValue || this._initialLocale;
-    }
+  updateNumberingSystemByLocale(newValue: string): void {
+    this._numberingSystem = this.resolveNumberingSystemByLocale(newValue);
+  }
+
+  updateNumberingSystem(newValue: NumberingSystem): void {
+    this._numberingSystem = newValue;
+  }
+
+  private resolveNumberingSystemByLocale(locale: string): NumberingSystem {
+    return DateTime.local().setLocale(locale).resolvedLocaleOptions()
+      .numberingSystem;
+  }
 }

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-time-adapter.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-time-adapter.spec.ts
@@ -1,6 +1,6 @@
 import { NgxMatTimepickerAdapter } from './ngx-mat-timepicker-adapter';
 import { NgxMatTimepickerPeriods } from '../models/ngx-mat-timepicker-periods.enum';
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 describe('NgxMatTimepickerAdapter', () => {
   describe('parseTime', () => {

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-time-adapter.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-time-adapter.spec.ts
@@ -148,7 +148,7 @@ describe('NgxMatTimepickerAdapter', () => {
           '11:43 pm',
           min,
           max,
-          'minutes',
+          'minute',
           minutesGap,
         );
       } catch (e: unknown) {

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.spec.ts
@@ -5,7 +5,7 @@ import { NgxMatTimepickerClockFace } from '../models/ngx-mat-timepicker-clock-fa
 import { NgxMatTimepickerService } from './ngx-mat-timepicker.service';
 import { NgxMatTimepickerPeriods } from '../models/ngx-mat-timepicker-periods.enum';
 import { NgxMatTimepickerAdapter } from './ngx-mat-timepicker-adapter';
-import { DateTime } from 'ts-luxon';
+import { DateTime } from 'luxon';
 
 describe('NgxMatTimepickerService', () => {
   const DEFAULT_HOUR: NgxMatTimepickerClockFace = {

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.ts
@@ -1,118 +1,139 @@
-import {Injectable} from "@angular/core";
+import { Injectable } from '@angular/core';
 //
-import {NgxMatTimepickerClockFace} from "../models/ngx-mat-timepicker-clock-face.interface";
-import {NgxMatTimepickerPeriods} from "../models/ngx-mat-timepicker-periods.enum";
-import {NgxMatTimepickerAdapter} from "./ngx-mat-timepicker-adapter";
+import { NgxMatTimepickerClockFace } from '../models/ngx-mat-timepicker-clock-face.interface';
+import { NgxMatTimepickerPeriods } from '../models/ngx-mat-timepicker-periods.enum';
+import { NgxMatTimepickerAdapter } from './ngx-mat-timepicker-adapter';
 //
-import {BehaviorSubject, Observable} from "rxjs";
-import {DateTime} from "ts-luxon";
+import { BehaviorSubject, Observable } from 'rxjs';
+import { DateTime } from 'luxon';
 
 const DEFAULT_HOUR: NgxMatTimepickerClockFace = {
-    time: 12,
-    angle: 360
+  time: 12,
+  angle: 360,
 };
 const DEFAULT_MINUTE: NgxMatTimepickerClockFace = {
-    time: 0,
-    angle: 360
+  time: 0,
+  angle: 360,
 };
 
 @Injectable({
-    providedIn: "root"
+  providedIn: 'root',
 })
 export class NgxMatTimepickerService {
+  set hour(hour: NgxMatTimepickerClockFace) {
+    this._hour$.next(hour);
+  }
 
+  set minute(minute: NgxMatTimepickerClockFace) {
+    this._minute$.next(minute);
+  }
 
-    set hour(hour: NgxMatTimepickerClockFace) {
-        this._hour$.next(hour);
+  set period(period: NgxMatTimepickerPeriods) {
+    const isPeriodValid =
+      period === NgxMatTimepickerPeriods.AM ||
+      period === NgxMatTimepickerPeriods.PM;
+
+    if (isPeriodValid) {
+      this._period$.next(period);
     }
+  }
 
-    set minute(minute: NgxMatTimepickerClockFace) {
-        this._minute$.next(minute);
+  get selectedHour(): Observable<NgxMatTimepickerClockFace> {
+    return this._hour$.asObservable();
+  }
+
+  get selectedMinute(): Observable<NgxMatTimepickerClockFace> {
+    return this._minute$.asObservable();
+  }
+
+  get selectedPeriod(): Observable<NgxMatTimepickerPeriods> {
+    return this._period$.asObservable();
+  }
+
+  private _hour$ = new BehaviorSubject<NgxMatTimepickerClockFace>(DEFAULT_HOUR);
+  private _minute$ = new BehaviorSubject<NgxMatTimepickerClockFace>(
+    DEFAULT_MINUTE,
+  );
+  private _period$ = new BehaviorSubject<NgxMatTimepickerPeriods>(
+    NgxMatTimepickerPeriods.AM,
+  );
+
+  getFullTime(format: number): string {
+    const selectedHour = this._hour$.getValue().time;
+    const selectedMinute = this._minute$.getValue().time;
+    const hour = selectedHour != null ? selectedHour : DEFAULT_HOUR.time;
+    const minute =
+      selectedMinute != null ? selectedMinute : DEFAULT_MINUTE.time;
+    const period = format === 12 ? this._period$.getValue() : '';
+    const time = `${hour}:${minute} ${period}`.trim();
+
+    return NgxMatTimepickerAdapter.formatTime(time, { format });
+  }
+
+  setDefaultTimeIfAvailable(
+    time: string,
+    min: DateTime,
+    max: DateTime,
+    format: number,
+    minutesGap?: number,
+  ) {
+    time || this._resetTime();
+    /* Workaround to double error message*/
+    try {
+      if (
+        NgxMatTimepickerAdapter.isTimeAvailable(
+          time,
+          min,
+          max,
+          'minute',
+          minutesGap,
+        )
+      ) {
+        this._setDefaultTime(time, format);
+      }
+    } catch (e) {
+      console.error(e);
     }
+  }
 
-    set period(period: NgxMatTimepickerPeriods) {
-        const isPeriodValid = (period === NgxMatTimepickerPeriods.AM) || (period === NgxMatTimepickerPeriods.PM);
+  private _resetTime(): void {
+    this.hour = { ...DEFAULT_HOUR };
+    this.minute = { ...DEFAULT_MINUTE };
+    this.period = NgxMatTimepickerPeriods.AM;
+  }
 
-        if (isPeriodValid) {
-            this._period$.next(period);
-        }
+  private _setDefaultTime(time: string, format: number) {
+    const defaultDto = NgxMatTimepickerAdapter.parseTime(time, { format });
+
+    if (defaultDto.isValid) {
+      const period = time.substring(time.length - 2).toUpperCase();
+      const hour = defaultDto.hour;
+
+      this.hour = {
+        ...DEFAULT_HOUR,
+        time: formatHourByPeriod(hour, period as NgxMatTimepickerPeriods),
+      };
+      this.minute = { ...DEFAULT_MINUTE, time: defaultDto.minute };
+      this.period = period as NgxMatTimepickerPeriods;
+    } else {
+      this._resetTime();
     }
-
-    get selectedHour(): Observable<NgxMatTimepickerClockFace> {
-        return this._hour$.asObservable();
-    }
-
-    get selectedMinute(): Observable<NgxMatTimepickerClockFace> {
-        return this._minute$.asObservable();
-    }
-
-    get selectedPeriod(): Observable<NgxMatTimepickerPeriods> {
-        return this._period$.asObservable();
-    }
-
-    private _hour$ = new BehaviorSubject<NgxMatTimepickerClockFace>(DEFAULT_HOUR);
-    private _minute$ = new BehaviorSubject<NgxMatTimepickerClockFace>(DEFAULT_MINUTE);
-    private _period$ = new BehaviorSubject<NgxMatTimepickerPeriods>(NgxMatTimepickerPeriods.AM);
-
-    getFullTime(format: number): string {
-        const selectedHour = this._hour$.getValue().time;
-        const selectedMinute = this._minute$.getValue().time;
-        const hour = selectedHour != null ? selectedHour : DEFAULT_HOUR.time;
-        const minute = selectedMinute != null ? selectedMinute : DEFAULT_MINUTE.time;
-        const period = format === 12 ? this._period$.getValue() : "";
-        const time = `${hour}:${minute} ${period}`.trim();
-
-        return NgxMatTimepickerAdapter.formatTime(time, {format});
-    }
-
-
-    setDefaultTimeIfAvailable(time: string, min: DateTime, max: DateTime, format: number, minutesGap?: number) {
-        time || this._resetTime();
-        /* Workaround to double error message*/
-        try {
-            if (NgxMatTimepickerAdapter.isTimeAvailable(time, min, max, "minutes", minutesGap)) {
-                this._setDefaultTime(time, format);
-            }
-        }
-        catch (e) {
-            console.error(e);
-        }
-    }
-
-    private _resetTime(): void {
-        this.hour = {...DEFAULT_HOUR};
-        this.minute = {...DEFAULT_MINUTE};
-        this.period = NgxMatTimepickerPeriods.AM;
-    }
-
-    private _setDefaultTime(time: string, format: number) {
-        const defaultDto = NgxMatTimepickerAdapter.parseTime(time, {format});
-
-        if (defaultDto.isValid) {
-            const period = time.substring(time.length - 2).toUpperCase();
-            const hour = defaultDto.hour;
-
-            this.hour = {...DEFAULT_HOUR, time: formatHourByPeriod(hour, period as NgxMatTimepickerPeriods)};
-            this.minute = {...DEFAULT_MINUTE, time: defaultDto.minute};
-            this.period = period as NgxMatTimepickerPeriods;
-
-        }
-        else {
-            this._resetTime();
-        }
-    }
+  }
 }
 
 /***
  *  Format hour in 24hours format to meridian (AM or PM) format
  */
-function formatHourByPeriod(hour: number, period: NgxMatTimepickerPeriods): number {
-    switch (period) {
-        case NgxMatTimepickerPeriods.AM:
-            return hour === 0 ? 12 : hour;
-        case NgxMatTimepickerPeriods.PM:
-            return hour === 12 ? 12 : hour - 12;
-        default:
-            return hour;
-    }
+function formatHourByPeriod(
+  hour: number,
+  period: NgxMatTimepickerPeriods,
+): number {
+  switch (period) {
+    case NgxMatTimepickerPeriods.AM:
+      return hour === 0 ? 12 : hour;
+    case NgxMatTimepickerPeriods.PM:
+      return hour === 12 ? 12 : hour - 12;
+    default:
+      return hour;
+  }
 }

--- a/projects/ngx-mat-timepicker/src/lib/tokens/ngx-mat-timepicker-config.token.ts
+++ b/projects/ngx-mat-timepicker/src/lib/tokens/ngx-mat-timepicker-config.token.ts
@@ -1,11 +1,12 @@
-import {InjectionToken, Provider} from "@angular/core";
-//
-import {NgxMatTimepickerConfig} from "../models/ngx-mat-timepicker-config.interface";
+import { InjectionToken, Provider } from '@angular/core';
 
-export const NGX_MAT_TIMEPICKER_CONFIG = new InjectionToken<NgxMatTimepickerConfig>("NGX_MAT_TIMEPICKER_CONFIG");
+import { NgxMatTimepickerConfig } from '../models/ngx-mat-timepicker-config.interface';
 
-export function provideNgxMatTimepickerOptions(config: NgxMatTimepickerConfig): Provider[] {
-    return [
-        {provide: NGX_MAT_TIMEPICKER_CONFIG, useValue: config},
-    ];
+export const NGX_MAT_TIMEPICKER_CONFIG =
+  new InjectionToken<NgxMatTimepickerConfig>('NGX_MAT_TIMEPICKER_CONFIG');
+
+export function provideNgxMatTimepickerOptions(
+  config: NgxMatTimepickerConfig,
+): Provider[] {
+  return [{ provide: NGX_MAT_TIMEPICKER_CONFIG, useValue: config }];
 }

--- a/projects/ngx-mat-timepicker/src/lib/tokens/ngx-mat-timepicker-time-locale.token.ts
+++ b/projects/ngx-mat-timepicker/src/lib/tokens/ngx-mat-timepicker-time-locale.token.ts
@@ -1,8 +1,11 @@
-import { InjectionToken } from "@angular/core";
-//
-import { NgxMatTimepickerAdapter } from "../services/ngx-mat-timepicker-adapter";
+import { InjectionToken } from '@angular/core';
 
-export const NGX_MAT_TIMEPICKER_LOCALE = new InjectionToken<string>("TimeLocale", {
-    providedIn: "root",
-    factory: () => NgxMatTimepickerAdapter.defaultLocale
-});
+import { NgxMatTimepickerAdapter } from '../services/ngx-mat-timepicker-adapter';
+
+export const NGX_MAT_TIMEPICKER_LOCALE = new InjectionToken<string>(
+  'TimeLocale',
+  {
+    providedIn: 'root',
+    factory: () => NgxMatTimepickerAdapter.defaultLocale,
+  },
+);

--- a/projects/ngx-mat-timepicker/src/lib/tokens/ngx-mat-timepicker-time-numberingsystem.token.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/tokens/ngx-mat-timepicker-time-numberingsystem.token.spec.ts
@@ -1,0 +1,20 @@
+import { Injector } from '@angular/core';
+
+import { NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM } from './ngx-mat-timepicker-time-numberingsystem.token';
+
+describe('TimeNumberingsystemToken', () => {
+  it('should return provided numberingsystem', () => {
+    const numberingsystem = 'latn';
+    const injector = Injector.create({
+      providers: [
+        {
+          provide: NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM,
+          useValue: numberingsystem,
+        },
+      ],
+    });
+    const actual = injector.get(NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM);
+
+    expect(actual).toBe(numberingsystem);
+  });
+});

--- a/projects/ngx-mat-timepicker/src/lib/tokens/ngx-mat-timepicker-time-numberingsystem.token.ts
+++ b/projects/ngx-mat-timepicker/src/lib/tokens/ngx-mat-timepicker-time-numberingsystem.token.ts
@@ -1,0 +1,9 @@
+import { InjectionToken } from '@angular/core';
+import type { NumberingSystem } from 'luxon';
+import { NgxMatTimepickerAdapter } from '../services/ngx-mat-timepicker-adapter';
+
+export const NGX_MAT_TIMEPICKER_NUMBERINGSYSTEM =
+  new InjectionToken<NumberingSystem>('TIMEPICKER_NUMBERINGSYSTEM', {
+    providedIn: 'root',
+    factory: () => NgxMatTimepickerAdapter.defaultNumberingSystem,
+  });

--- a/projects/ngx-mat-timepicker/src/lib/utils/datetime-unit-fix.utils.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/utils/datetime-unit-fix.utils.spec.ts
@@ -1,0 +1,25 @@
+import { fixDateTimeUnit } from './datetime-unit-fix.utils';
+
+describe('fixDateTimeUnit', () => {
+  it('should fix unit', () => {
+    expect(fixDateTimeUnit('hours')).toBe('hour');
+    expect(fixDateTimeUnit('minutes')).toBe('minute');
+
+    expect(fixDateTimeUnit('hour')).toBe('hour');
+    expect(fixDateTimeUnit('minute')).toBe('minute');
+  });
+
+  it('should print deprecation warning', () => {
+    jest.spyOn(console, 'warn');
+
+    fixDateTimeUnit('hours');
+    expect(console.warn).toHaveBeenCalledWith(
+      `'hours' is deprecated. Use 'hour' instead.`,
+    );
+
+    fixDateTimeUnit('minutes');
+    expect(console.warn).toHaveBeenCalledWith(
+      `'minutes' is deprecated. Use 'minute' instead.`,
+    );
+  });
+});

--- a/projects/ngx-mat-timepicker/src/lib/utils/datetime-unit-fix.utils.ts
+++ b/projects/ngx-mat-timepicker/src/lib/utils/datetime-unit-fix.utils.ts
@@ -1,0 +1,34 @@
+import { DateTimeUnit } from 'luxon';
+
+export type DateTimeUnitWithDeprecatedTypes =
+  | DateTimeUnit
+  | 'hours'
+  | 'minutes';
+
+export function fixDateTimeUnit(
+  unit: DateTimeUnitWithDeprecatedTypes,
+): DateTimeUnit {
+  switch (unit) {
+    case 'hours':
+    case 'minutes':
+      printDeprecationWarning(unit);
+      return fixUnit(unit);
+    default:
+      return unit;
+  }
+}
+
+export function fixUnit(unit: DateTimeUnitWithDeprecatedTypes): DateTimeUnit {
+  switch (unit) {
+    case 'hours':
+      return 'hour';
+    case 'minutes':
+      return 'minute';
+    default:
+      return unit;
+  }
+}
+
+function printDeprecationWarning(unit: DateTimeUnitWithDeprecatedTypes) {
+  console.warn(`'${unit}' is deprecated. Use '${fixUnit(unit)}' instead.`);
+}

--- a/projects/ngx-mat-timepicker/src/lib/utils/ngx-mat-timepicker.utils.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/utils/ngx-mat-timepicker.utils.spec.ts
@@ -2,7 +2,7 @@ import {NgxMatTimepickerPeriods} from "../models/ngx-mat-timepicker-periods.enum
 import {NgxMatTimepickerUtils} from "./ngx-mat-timepicker.utils";
 import {NgxMatTimepickerAdapter} from "../services/ngx-mat-timepicker-adapter";
 //
-import {DateTime} from "ts-luxon";
+import {DateTime} from 'luxon';
 
 describe("TimepickerTime", () => {
     describe("Hour", () => {

--- a/projects/ngx-mat-timepicker/src/lib/utils/ngx-mat-timepicker.utils.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/utils/ngx-mat-timepicker.utils.spec.ts
@@ -226,7 +226,7 @@ describe("TimepickerTime", () => {
         it("should return false if hour less than min value", () => {
             const min = NgxMatTimepickerAdapter.parseTime("11:11 am", {locale});
             const time = NgxMatTimepickerAdapter.parseTime("10:12 am", {locale});
-            expect(NgxMatTimepickerAdapter.isSameOrAfter(time, min, "hours")).toBeFalsy();
+            expect(NgxMatTimepickerAdapter.isSameOrAfter(time, min, "hour")).toBeFalsy();
         });
 
         it("should return false", () => {
@@ -252,7 +252,7 @@ describe("TimepickerTime", () => {
         it("should return false if hour more than max", () => {
             const max = NgxMatTimepickerAdapter.parseTime("11:11 am", {locale});
             const time = NgxMatTimepickerAdapter.parseTime("12:10 pm", {locale});
-            expect(NgxMatTimepickerAdapter.isSameOrBefore(time, max, "hours")).toBeFalsy();
+            expect(NgxMatTimepickerAdapter.isSameOrBefore(time, max, "hour")).toBeFalsy();
         });
 
         it("should return false", () => {
@@ -285,7 +285,7 @@ describe("TimepickerTime", () => {
             const max = NgxMatTimepickerAdapter.parseTime("03:00 pm", {locale});
             const time = NgxMatTimepickerAdapter.parseTime("04:05 pm", {locale});
 
-            expect(NgxMatTimepickerAdapter.isBetween(time, min, max, "hours")).toBeFalsy();
+            expect(NgxMatTimepickerAdapter.isBetween(time, min, max, "hour")).toBeFalsy();
         });
 
         it("should return false", () => {

--- a/projects/ngx-mat-timepicker/src/lib/utils/ngx-mat-timepicker.utils.ts
+++ b/projects/ngx-mat-timepicker/src/lib/utils/ngx-mat-timepicker.utils.ts
@@ -3,7 +3,7 @@ import {NgxMatTimepickerAdapter} from "../services/ngx-mat-timepicker-adapter";
 import {NgxMatTimepickerFormat} from "../models/ngx-mat-timepicker-format.enum";
 import {NgxMatTimepickerDisabledConfig} from "../models/ngx-mat-timepicker-disabled-config.interface";
 //
-import {DateTime} from "ts-luxon";
+import {DateTime} from 'luxon';
 
 // @dynamic
 export class NgxMatTimepickerUtils {
@@ -19,7 +19,7 @@ export class NgxMatTimepickerUtils {
 
                 return {
                     ...value,
-                    disabled: !NgxMatTimepickerAdapter.isTimeAvailable(currentTime, config.min, config.max, "hours")
+                    disabled: !NgxMatTimepickerAdapter.isTimeAvailable(currentTime, config.min, config.max, "hour")
                 };
             });
         }
@@ -41,7 +41,7 @@ export class NgxMatTimepickerUtils {
 
                 return {
                     ...value,
-                    disabled: !NgxMatTimepickerAdapter.isTimeAvailable(currentTime.toFormat(NgxMatTimepickerFormat.TWELVE), config.min, config.max, "minutes")
+                    disabled: !NgxMatTimepickerAdapter.isTimeAvailable(currentTime.toFormat(NgxMatTimepickerFormat.TWELVE), config.min, config.max, "minute")
                 };
             });
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3336,6 +3336,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/luxon@^3.3.6":
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.6.tgz#1c04d0c15b8d784a0a8c4d7dbfa1c5fd38a72a77"
+  integrity sha512-LblarKeI26YsMLxHDIQ0295wPSLjkl98eNwDcVhz3zbo1H+kfnkzR01H5Ai5LBzSeddX0ZJSpGwKEZihGb5diw==
+
 "@types/mime@*":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.4.tgz#2198ac274de6017b44d941e00261d5bc6a0e0a45"
@@ -7326,6 +7331,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+luxon@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.4.tgz#cf20dc27dc532ba41a169c43fdcc0063601577af"
+  integrity sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==
+
 magic-string@0.30.5:
   version "0.30.5"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.5.tgz#1994d980bd1c8835dc6e78db7cbd4ae4f24746f9"
@@ -9524,11 +9534,6 @@ ts-jest@^29.0.0, ts-jest@^29.1.1:
     make-error "1.x"
     semver "^7.5.3"
     yargs-parser "^21.0.1"
-
-ts-luxon@^4.3.2:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/ts-luxon/-/ts-luxon-4.4.0.tgz#d2e5928612c1d24ac836c9d61b94d4b1af2b2ab7"
-  integrity sha512-da38ShNr8dHAXEMg2sBwecOmNus2Fd7Q4h/MAXUve00NVxaeEbR0DMbF2UECBCy22qKPN6F6fypfDdVUniLTEw==
 
 ts-node@~10.9.1:
   version "10.9.1"


### PR DESCRIPTION
This change will replace `ts-luxon` with `luxon`.

- no difference in bundle-size
- luxon is regularly updated
- ts-luxon is less trustworthy

Additionally failing tests were fixed with the addition of a Numberingsystem DI token